### PR TITLE
fix json(b) array bug

### DIFF
--- a/packages/data-api-local/src/integration.postgres.test.ts
+++ b/packages/data-api-local/src/integration.postgres.test.ts
@@ -205,7 +205,8 @@ describe('#executeStatement', () => {
         '12345.67'::numeric(10, 2) AS "numericValue",
         'helloWorld'::varchar AS "varcharValue",
         json_build_object('foo', 1, 'bar', 2) as "jsonValue",
-        '2021-01-01'::date AS "dateValue"
+        '2021-01-01'::date AS "dateValue",
+        json_build_array(1,2,'3',4,5) as "jsonArray"
     `)
     expect(result).toMatchObject({
       numberOfRecordsUpdated: 0,
@@ -220,6 +221,7 @@ describe('#executeStatement', () => {
         { stringValue: 'helloWorld' },
         { stringValue: '{"foo":1,"bar":2}' },
         { stringValue: '2021-01-01' },
+        { stringValue: '[1,2,"3",4,5]' }
       ]],
       columnMetadata: [{
         ...metadataDefaults,
@@ -305,6 +307,14 @@ describe('#executeStatement', () => {
         name: 'dateValue',
         label: 'dateValue',
         typeName: 'date'
+      }, {
+        ...metadataDefaults,
+        precision: 2147483647,
+        scale: 0,
+        type: 114,
+        name: 'jsonArray',
+        label: 'jsonArray',
+        typeName: 'json'
       }]
     })
   })

--- a/packages/data-api-local/src/utils/transformResult.ts
+++ b/packages/data-api-local/src/utils/transformResult.ts
@@ -53,6 +53,10 @@ const transformValue = (field: FieldDef, value: unknown): RDSDataService.Types.F
   if (value === null) {
     return { isNull: true }
   } else {
+    // should always serialize JSON(B) into `stringValue`
+    if ([types.builtins.JSON, types.builtins.JSONB].includes(field.dataTypeID)) {
+      return { stringValue: transformStringValue(value) }
+    }
     if (Array.isArray(value)) {
       return { arrayValue: transformArray(field.dataTypeID, value) }
     }


### PR DESCRIPTION
json(b) arrays should always be serialized into `stringValue` and not
`arrayValue`
that's how actual Aurora rds-data works